### PR TITLE
Add hook for update initramfs after NVIDIA driver update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ os-release.hook | Runs `cachyos-hooks-runner` after package `filesystem` has bee
 cachyos-reboot-required | Notifies user to reboot after essential system files have been updated.
 cachyos-check-reboot-required | Filters a selection of kernel targets to `cachyos-reboot-required`.
 cachyos-reboot-required.hook | Runs `cachyos-reboot-required` after any listed essential system files have been updated.
+cachyos-nvidia.hook | Avoids black screens after driver updates with `nvidia-drm.modeset=1` enabled.

--- a/cachyos-nvidia.hook
+++ b/cachyos-nvidia.hook
@@ -1,0 +1,14 @@
+[Trigger]
+Operation=Install
+Operation=Upgrade
+Operation=Remove
+Type=File
+Target=etc/modprobe.d/nvidia.conf
+Target=usr/src/nvidia-*/dkms.conf
+Target=usr/lib/modules/*/extramodules/nvidia.ko.*
+
+[Action]
+Description=Update Nvidia module in initcpio (for DRM KMS)
+When=PostTransaction
+NeedsTargets
+Exec=/bin/sh -c 'if command -v mkinitcpio >/dev/null 2>&1; then mkinitcpio -P; else if command -v /usr/lib/booster/regenerate_images >/dev/null 2>&1; then /usr/lib/booster/regenerate_images; else printf "\\033[31m mkinitcpio not found, please update initramfs manually\\033[0m\\n"; fi; fi'


### PR DESCRIPTION
Avoids black screens after driver updates with `nvidia-drm.modeset=1` enabled.

Based on https://aur.archlinux.org/cgit/aur.git/tree/nvidia-tweaks.hook?h=nvidia-tweaks

Related with: https://github.com/CachyOS/CachyOS-Settings/pull/7

@ptr1337 