### PR TITLE
Fixing non-zero exit code in cachyos-reboot-required script

### DIFF
--- a/cachyos-reboot-required
+++ b/cachyos-reboot-required
@@ -41,11 +41,11 @@ while read -r target; do
         linux-cachyos-nvidia*)
             [[ "$kernelname" = linux-cachyos* ]] && _notify;;
         btrfs-progs)
-            [ -n "$(mount -t btrfs)" ] && _notify;;
+            [ -n "$(mount -t btrfs)" ] && _notify || : ;;
         xfsprogs)
-            [ -n "$(mount -t xfs)" ] && _notify;;
+            [ -n "$(mount -t xfs)" ] && _notify || : ;;
         e2fsprogs)
-            [ -n "$(mount -t ext4)" ] && _notify;;
+            [ -n "$(mount -t ext4)" ] && _notify || : ;;
         *) _notify ;;
     esac
 done


### PR DESCRIPTION
When reinstalling filesystem progs where is a check for mounted filesystems. If one does not have, for example, any XFS filesystem mounted when reinstalling, or upgrading xfsprogs the script produces an error in pacman execution. To avoid need to add "|| :" in if..then..else statement to do nothing instead of exiting the script with non-zero code.