### PR TITLE
cachyos-branding: Fix condition check for adding missing ID_LIKE

### DIFF
--- a/cachyos-branding
+++ b/cachyos-branding
@@ -22,7 +22,7 @@ update_os_release() {
         -e 's|^LOGO=.*$|LOGO=cachyos|'
 
     # add missing ID_LIKE=
-    if ! grep -q "^ID_LIKE=" "$os_release" && ! grep -q "^ID=" "$os_release"; then
+    if ! grep -q "^ID_LIKE=" "$os_release" && grep -q "^ID=" "$os_release"; then
         sed -i "$os_release" -e '/^ID=/a \ID_LIKE=arch'
     fi
 }


### PR DESCRIPTION
The grep check for "ID=" should not be negated since we want to find it before appending ID_LIKE to the line below it.

Fixes: f8e565cd5b58 ("Minor refactoring & cleanups")
Closes: #14